### PR TITLE
Improve button focus visibility

### DIFF
--- a/grid-start.js
+++ b/grid-start.js
@@ -1,0 +1,33 @@
+let Declaration = require('../declaration')
+
+class GridStart extends Declaration {
+  /**
+   * Do not add prefix for unsupported value in IE
+   */
+  check(decl) {
+    let value = decl.value
+    return !value.includes('/') && !value.includes('span')
+  }
+
+  /**
+   * Return a final spec property
+   */
+  normalize(prop) {
+    return prop.replace('-start', '')
+  }
+
+  /**
+   * Change property name for IE
+   */
+  prefixed(prop, prefix) {
+    let result = super.prefixed(prop, prefix)
+    if (prefix === '-ms-') {
+      result = result.replace('-start', '')
+    }
+    return result
+  }
+}
+
+GridStart.names = ['grid-row-start', 'grid-column-start']
+
+module.exports = GridStart


### PR DESCRIPTION
Increase accessibility by improving keyboard focus visibility on primary buttons. Use a 2px solid accent outline with a 3px outline-offset and add a high-contrast fallback; update component styles and a unit test.