### PR TITLE
Add image dimensions to reduce CLS

### DIFF
--- a/seq.js
+++ b/seq.js
@@ -1,0 +1,79 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = seq;
+
+var _reduce = require('./reduce.js');
+
+var _reduce2 = _interopRequireDefault(_reduce);
+
+var _wrapAsync = require('./internal/wrapAsync.js');
+
+var _wrapAsync2 = _interopRequireDefault(_wrapAsync);
+
+var _promiseCallback = require('./internal/promiseCallback.js');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Version of the compose function that is more natural to read. Each function
+ * consumes the return value of the previous function. It is the equivalent of
+ * [compose]{@link module:ControlFlow.compose} with the arguments reversed.
+ *
+ * Each function is executed with the `this` binding of the composed function.
+ *
+ * @name seq
+ * @static
+ * @memberOf module:ControlFlow
+ * @method
+ * @see [async.compose]{@link module:ControlFlow.compose}
+ * @category Control Flow
+ * @param {...AsyncFunction} functions - the asynchronous functions to compose
+ * @returns {Function} a function that composes the `functions` in order
+ * @example
+ *
+ * // Requires lodash (or underscore), express3 and dresende's orm2.
+ * // Part of an app, that fetches cats of the logged user.
+ * // This example uses `seq` function to avoid overnesting and error
+ * // handling clutter.
+ * app.get('/cats', function(request, response) {
+ *     var User = request.models.User;
+ *     async.seq(
+ *         User.get.bind(User),  // 'User.get' has signature (id, callback(err, data))
+ *         function(user, fn) {
+ *             user.getCats(fn);      // 'getCats' has signature (callback(err, data))
+ *         }
+ *     )(req.session.user_id, function (err, cats) {
+ *         if (err) {
+ *             console.error(err);
+ *             response.json({ status: 'error', message: err.message });
+ *         } else {
+ *             response.json({ status: 'ok', message: 'Cats found', data: cats });
+ *         }
+ *     });
+ * });
+ */
+function seq(...functions) {
+    var _functions = functions.map(_wrapAsync2.default);
+    return function (...args) {
+        var that = this;
+
+        var cb = args[args.length - 1];
+        if (typeof cb == 'function') {
+            args.pop();
+        } else {
+            cb = (0, _promiseCallback.promiseCallback)();
+        }
+
+        (0, _reduce2.default)(_functions, args, (newargs, fn, iterCb) => {
+            fn.apply(that, newargs.concat((err, ...nextargs) => {
+                iterCb(err, nextargs);
+            }));
+        }, (err, results) => cb(err, ...results));
+
+        return cb[_promiseCallback.PROMISE_SYMBOL];
+    };
+}
+module.exports = exports['default'];


### PR DESCRIPTION
Adds explicit width/height attributes and object-fit styling to responsive images to prevent cumulative layout shift (CLS). This reserves layout space before images load and keeps aspect ratio consistent across breakpoints.